### PR TITLE
Necklace now correctly renders undying totems in hud

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ plugins {
 	id 'maven-publish'
 	id 'eclipse'
 	id 'net.neoforged.gradle' version '[6.0.18,6.2)'
+	id 'org.spongepowered.mixin' version '0.7.+'
 }
 
 group = "net.foxmcloud.draconicadditions"
@@ -57,6 +58,11 @@ repositories {
 	maven { url = "https://maven.covers1624.net/" }
 	maven { url = "https://maven.blamejared.com/" }
 	maven { url = "https://maven.theillusivec4.top/" }
+}
+
+mixin {
+	add(sourceSets.main, "mixins.draconicadditions.refmap.json")
+	config 'mixins.draconicadditions.json'
 }
 
 dependencies {

--- a/src/main/java/net/foxmcloud/draconicadditions/mixins/HUDTotemDisplay.java
+++ b/src/main/java/net/foxmcloud/draconicadditions/mixins/HUDTotemDisplay.java
@@ -21,8 +21,9 @@ import java.util.List;
 public class HUDTotemDisplay {
 	@ModifyVariable(method = "tick", at = @At("STORE"), name = "totems")
 	private List<UndyingEntity> fixTotemCount(List<UndyingEntity> totems) {
-		if (Minecraft.getInstance().player == null) return totems;
-		ItemStack necklaceStack = EquipmentManager.findItem((e) -> e.getItem() instanceof ModularNecklace, Minecraft.getInstance().player);
+		Minecraft mc = Minecraft.getInstance();
+		if (mc.player == null) return totems;
+		ItemStack necklaceStack = EquipmentManager.findItem((e) -> e.getItem() instanceof ModularNecklace, mc.player);
 		LazyOptional<ModuleHost> optionalNecklaceModuleHost = necklaceStack.getCapability(DECapabilities.MODULE_HOST_CAPABILITY);
 		if (!necklaceStack.isEmpty() && optionalNecklaceModuleHost.isPresent()) {
 			ModuleHost necklaceHost = optionalNecklaceModuleHost.orElseThrow(IllegalStateException::new);

--- a/src/main/java/net/foxmcloud/draconicadditions/mixins/HUDTotemDisplay.java
+++ b/src/main/java/net/foxmcloud/draconicadditions/mixins/HUDTotemDisplay.java
@@ -1,0 +1,43 @@
+package net.foxmcloud.draconicadditions.mixins;
+
+import com.brandon3055.draconicevolution.api.capability.DECapabilities;
+import com.brandon3055.draconicevolution.api.capability.ModuleHost;
+import com.brandon3055.draconicevolution.api.modules.ModuleTypes;
+import com.brandon3055.draconicevolution.api.modules.entities.UndyingEntity;
+import com.brandon3055.draconicevolution.client.render.hud.ShieldHudElement;
+import com.brandon3055.draconicevolution.integration.equipment.EquipmentManager;
+import net.foxmcloud.draconicadditions.items.curios.ModularNecklace;
+import net.minecraft.client.Minecraft;
+import net.minecraft.world.item.ItemStack;
+import net.minecraftforge.common.util.LazyOptional;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
+
+import java.util.Comparator;
+import java.util.List;
+
+@Mixin(ShieldHudElement.class)
+public class HUDTotemDisplay {
+	@ModifyVariable(method = "tick", at = @At("STORE"), name = "totems")
+	private List<UndyingEntity> fixTotemCount(List<UndyingEntity> totems) {
+		//Safeguard, could probably be removed but IDE won't shut up without
+		if (Minecraft.getInstance().player == null) return totems;
+
+		ItemStack necklaceStack = EquipmentManager.findItem((e) -> e.getItem() instanceof ModularNecklace, Minecraft.getInstance().player);
+		LazyOptional<ModuleHost> optionalNecklaceModuleHost = necklaceStack.getCapability(DECapabilities.MODULE_HOST_CAPABILITY);
+
+		if (!necklaceStack.isEmpty() && optionalNecklaceModuleHost.isPresent()) {
+			ModuleHost necklaceHost = optionalNecklaceModuleHost.orElseThrow(IllegalStateException::new);
+			totems.addAll(necklaceHost.getEntitiesByType(ModuleTypes.UNDYING)
+					.map((e) -> (UndyingEntity) e)
+					.sorted(Comparator.comparing((e) -> e.getModule().getModuleTechLevel().index))
+					.toList());
+
+			//Deduplicate in case the player is only wearing the necklace, as DE will already render the totems then
+			totems = totems.stream().distinct().toList();
+		}
+
+		return totems;
+	}
+}

--- a/src/main/java/net/foxmcloud/draconicadditions/mixins/HUDTotemDisplay.java
+++ b/src/main/java/net/foxmcloud/draconicadditions/mixins/HUDTotemDisplay.java
@@ -27,11 +27,13 @@ public class HUDTotemDisplay {
 		LazyOptional<ModuleHost> optionalNecklaceModuleHost = necklaceStack.getCapability(DECapabilities.MODULE_HOST_CAPABILITY);
 		if (!necklaceStack.isEmpty() && optionalNecklaceModuleHost.isPresent()) {
 			ModuleHost necklaceHost = optionalNecklaceModuleHost.orElseThrow(IllegalStateException::new);
-			totems.addAll(necklaceHost.getEntitiesByType(ModuleTypes.UNDYING)
-					.map((e) -> (UndyingEntity) e)
-					.sorted(Comparator.comparing((e) -> e.getModule().getModuleTechLevel().index))
-					.toList());
-			totems = totems.stream().distinct().toList();
+			List<UndyingEntity> entities = necklaceHost.getEntitiesByType(ModuleTypes.UNDYING)
+				.map((e) -> (UndyingEntity) e)
+				.sorted(Comparator.comparing((e) -> e.getModule().getModuleTechLevel().index))
+				.toList();
+			if (!totems.containsAll(entities)) {
+				totems.addAll(entities);
+			}
 		}
 		return totems;
 	}

--- a/src/main/java/net/foxmcloud/draconicadditions/mixins/HUDTotemDisplay.java
+++ b/src/main/java/net/foxmcloud/draconicadditions/mixins/HUDTotemDisplay.java
@@ -21,23 +21,17 @@ import java.util.List;
 public class HUDTotemDisplay {
 	@ModifyVariable(method = "tick", at = @At("STORE"), name = "totems")
 	private List<UndyingEntity> fixTotemCount(List<UndyingEntity> totems) {
-		//Safeguard, could probably be removed but IDE won't shut up without
 		if (Minecraft.getInstance().player == null) return totems;
-
 		ItemStack necklaceStack = EquipmentManager.findItem((e) -> e.getItem() instanceof ModularNecklace, Minecraft.getInstance().player);
 		LazyOptional<ModuleHost> optionalNecklaceModuleHost = necklaceStack.getCapability(DECapabilities.MODULE_HOST_CAPABILITY);
-
 		if (!necklaceStack.isEmpty() && optionalNecklaceModuleHost.isPresent()) {
 			ModuleHost necklaceHost = optionalNecklaceModuleHost.orElseThrow(IllegalStateException::new);
 			totems.addAll(necklaceHost.getEntitiesByType(ModuleTypes.UNDYING)
 					.map((e) -> (UndyingEntity) e)
 					.sorted(Comparator.comparing((e) -> e.getModule().getModuleTechLevel().index))
 					.toList());
-
-			//Deduplicate in case the player is only wearing the necklace, as DE will already render the totems then
 			totems = totems.stream().distinct().toList();
 		}
-
 		return totems;
 	}
 }

--- a/src/main/resources/mixins.draconicadditions.json
+++ b/src/main/resources/mixins.draconicadditions.json
@@ -1,0 +1,11 @@
+{
+	"required": false,
+	"minVersion": "0.8",
+	"package": "net.foxmcloud.draconicadditions.mixins",
+	"refmap": "mixins.draconicadditions.refmap.json",
+	"target": "@env(DEFAULT)",
+	"compatibilityLevel": "JAVA_17",
+	"client": [
+		"HUDTotemDisplay"
+	]
+}


### PR DESCRIPTION
Added a mixin to allow Draconic Evolutions Hud to also include undying totems if the player is wearing the armor and the necklace at the same time.